### PR TITLE
removed assignment of python built-in function type() to member of class Magic

### DIFF
--- a/magic.py
+++ b/magic.py
@@ -8,7 +8,6 @@ class Magic:
         self.name = name
         self.mp_cost = mp_cost
         self.dmg = dmg
-        self.type = type
         self.high_dmg = dmg + 15
         self.low_dmg = dmg - 15
         self.magic_type = magic_type


### PR DESCRIPTION
`self.type = type`
assigns the type() function as a member variable to class Magic.

type() is a built-in function ( https://docs.python.org/3/library/functions.html#type ) and the member variable type is not used in further parts of the python project.

This pull request suggests removing the certain line.